### PR TITLE
Make cookie regexp case-insensitive

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,7 +104,7 @@ function rewriteCookieHosts(existingHeaders, opts, applyTo, req) {
     var rewrittenCookie = existingCookies[i].replace(/(Domain)=[a-z\.-_]*?(;|$)/gi, '$1=' + rewriteHostname + '$2');
 
     if (!req.connection.encrypted) {
-      rewrittenCookie = rewrittenCookie.replace(/;\s*?(Secure)/, '');
+      rewrittenCookie = rewrittenCookie.replace(/;\s*?(Secure)/i, '');
     }
     rewrittenCookies.push(rewrittenCookie);
   }


### PR DESCRIPTION
I noticed that the `cookieRewrite` option was not fully working on some production servers that I wanted to proxy to. It turned out that the `Secure` flag was in lowercase on those servers. This simply changes the regexp to be case-insensitive.